### PR TITLE
Apply fixes to kubeform chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,13 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cluster: [v1.12.10, v1.13.10, v1.14.6, v1.15.3, v1.16.2]
     steps:
+
+    - name: Set up Go 1.14
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.14
+      id: go
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
@@ -24,15 +27,35 @@ jobs:
       run: |
         sudo apt-get -qq update || true
         sudo apt-get install -y bzr
+        # install yq
+        curl -fsSL -o yq https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
+        chmod +x yq
+        sudo mv yq /usr/local/bin/yq
+        # install kubectl
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl
+        chmod +x ./kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
         make ci
 
-    - name: Create Kubernetes ${{ matrix.cluster }} cluster
+  kubernetes:
+    name: Kubernetes
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        k8s: [v1.11.10, v1.12.10, v1.13.12, v1.14.10, v1.15.7, v1.16.4, v1.17.2, v1.18.0]
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v1
+
+    - name: Create Kubernetes ${{ matrix.k8s }} cluster
       id: kind
       uses: engineerd/setup-kind@v0.1.0
       with:
         version: v0.7.0
         config: hack/kubernetes/kind.yaml
-        image: kindest/node:${{ matrix.cluster }}
+        image: kindest/node:${{ matrix.k8s }}
 
     - name: Prepare cluster for testing
       id: local-path
@@ -45,13 +68,18 @@ jobs:
         kubectl wait --for=condition=Ready nodes --all --timeout=5m
         kubectl get nodes
         echo
-        echo "install helm 3"
-        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+        kubectl version
+        echo
+        echo "installing local-path provisioner ..."
+        kubectl delete storageclass --all
+        kubectl apply -f https://github.com/rancher/local-path-provisioner/raw/v0.0.12/deploy/local-path-storage.yaml
+        kubectl wait --for=condition=Ready pods -n local-path-storage --all --timeout=5m
+        kubectl apply -f hack/kubernetes/storageclass/standard.yaml
         echo
         echo "create docker-registry secret"
         kubectl create secret docker-registry ${REGISTRY_SECRET} --namespace=kube-system --docker-server=https://index.docker.io/v1/ --docker-username=${USERNAME} --docker-password=${DOCKER_TOKEN}
 
     - name: Test charts
       run: |
-        export KUBECONFIG="$HOME/.kube/config"
+        export KUBECONFIG="${HOME}/.kube/config"
         make ct

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ ARCH := $(if $(GOARCH),$(GOARCH),$(shell go env GOARCH))
 BASEIMAGE_PROD   ?= gcr.io/distroless/static
 BASEIMAGE_DBG    ?= debian:stretch
 
-GO_VERSION       ?= 1.12.12
-BUILD_IMAGE      ?= appscode/golang-dev:$(GO_VERSION)-stretch
-CHART_TEST_IMAGE ?= quay.io/helmpack/chart-testing:v2.4.0
+GO_VERSION       ?= 1.14.2
+BUILD_IMAGE      ?= appscode/golang-dev:$(GO_VERSION)
+CHART_TEST_IMAGE ?= quay.io/helmpack/chart-testing:v3.0.0-rc.1
 
 OUTBIN = bin/$(OS)_$(ARCH)/$(BIN)
 ifeq ($(OS),windows)

--- a/charts/kubeform/templates/_helpers.tpl
+++ b/charts/kubeform/templates/_helpers.tpl
@@ -3,36 +3,61 @@
 Expand the name of the chart.
 */}}
 {{- define "kubeform.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
 */}}
 {{- define "kubeform.fullname" -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubeform.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubeform.labels" -}}
+helm.sh/chart: {{ include "kubeform.chart" . }}
+{{ include "kubeform.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubeform.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubeform.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
 {{- define "kubeform.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{ default (include "kubeform.fullname" .) .Values.serviceAccount.name }}
-{{- else -}}
-    {{ default "default" .Values.serviceAccount.name }}
-{{- end -}}
-{{- end -}}
-
-{{- define "kubeform.labels" -}}
-chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-app: "{{ template "kubeform.name" . }}"
-release: {{ .Release.Name | quote}}
-heritage: "{{ .Release.Service }}"
-{{- end -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kubeform.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/kubeform/templates/deployment.yaml
+++ b/charts/kubeform/templates/deployment.yaml
@@ -1,32 +1,40 @@
+{{- $major := default "0" .Capabilities.KubeVersion.Major | trimSuffix "+" | int64 }}
+{{- $minor := default "0" .Capabilities.KubeVersion.Minor | trimSuffix "+" | int64 }}
+{{- $criticalAddon := and .Values.criticalAddon (or (eq .Release.Namespace "kube-system") (and (ge $major 1) (ge $minor 17))) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "kubeform.fullname" . }}
+  name: {{ include "kubeform.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubeform.labels" . | nindent 4 }}
-{{- if .Values.annotations }}
+  {{- with .Values.annotations }}
   annotations:
-{{ toYaml .Values.annotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: "{{ template "kubeform.name" . }}"
-      release: "{{ .Release.Name }}"
+      {{- include "kubeform.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "kubeform.labels" . | nindent 8 }}
-{{- with .Values.annotations }}
+        {{- include "kubeform.selectorLabels" . | nindent 8 }}
+    {{- with .Values.podAnnotations }}
       annotations:
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
-      serviceAccountName: {{ template "kubeform.serviceAccountName" . }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "kubeform.serviceAccountName" . }}
       containers:
       - name: operator
+        securityContext:
+          {{- toYaml .Values.operator.securityContext | nindent 10 }}
         image: {{ .Values.operator.registry }}/{{ .Values.operator.repository }}:{{ .Values.operator.tag }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         env:
@@ -38,24 +46,28 @@ spec:
         args:
           - run
           - --secret-key=$(TF_STATE_ENC_KEY)
-{{- if or .Values.tolerations (and .Values.criticalAddon (eq .Release.Namespace "kube-system")) }}
+        resources:
+          {{- toYaml .Values.operator.resources | nindent 10 }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+    {{- if or .Values.tolerations $criticalAddon }}
       tolerations:
-{{- if .Values.tolerations }}
-{{ toYaml .Values.tolerations | indent 8 }}
-{{- end -}}
-{{- if and .Values.criticalAddon (eq .Release.Namespace "kube-system") }}
-      - key: CriticalAddonsOnly
-        operator: Exists
-{{- end -}}
-{{- end -}}
-{{- if .Values.affinity }}
+      {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $criticalAddon }}
+        - key: CriticalAddonsOnly
+          operator: Exists
+      {{- end -}}
+    {{- end -}}
+    {{- with .Values.affinity }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
-{{- end -}}
-{{- if .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-{{- end -}}
-{{- if and .Values.criticalAddon (eq .Release.Namespace "kube-system") }}
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if $criticalAddon }}
       priorityClassName: system-cluster-critical
-{{- end -}}
+    {{- end -}}

--- a/charts/kubeform/templates/service-account.yaml
+++ b/charts/kubeform/templates/service-account.yaml
@@ -1,9 +1,0 @@
-{{ if .Values.serviceAccount.create }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ template "kubeform.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "kubeform.labels" . | nindent 4 }}
-{{ end }}

--- a/charts/kubeform/templates/serviceaccount.yaml
+++ b/charts/kubeform/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kubeform.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubeform.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kubeform/values.yaml
+++ b/charts/kubeform/values.yaml
@@ -1,21 +1,44 @@
 # Default values for kubeform.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
 replicaCount: 1
+
 # Docker registry containing Kubeform Controller (kfc) image
 operator:
   registry: kubeform
   repository: kfc
   tag: v0.0.2
 
+## Optionally specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+## example: helm template charts/kubeform \
+##            --set imagePullSecrets[0].name=abc,imagePullSecrets[1].name=xyz
+imagePullSecrets: []
+
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 ##
 imagePullPolicy: IfNotPresent
 
-## Annotations passed to operator pod(s).
+## Installs Stash operator as critical addon
+## https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+criticalAddon: false
+
+## Log level for operator
+logLevel: 3
+
+## Annotations passed to operator deployment.
 ##
 annotations: {}
+
+## Annotations passed to operator pod(s).
+##
+podAnnotations: {}
 
 ## Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
@@ -25,17 +48,21 @@ nodeSelector:
 ## Tolerations for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-tolerations: {}
+tolerations: []
 
 ## Affinity for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ##
 affinity: {}
 
+podSecurityContext: {}
+
 serviceAccount:
-  # Specifies whether a ServiceAccount should be created
+  # Specifies whether a service account should be created
   create: true
-  # The name of the ServiceAccount to use.
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
 


### PR DESCRIPTION
- Fixes toleration indentation ref: https://github.com/kubedb/installer/pull/58
- Use separate annotations for deployment and pods
- Add security context for pods and containers
- Use image pull secrets via deployment
- Add pod & container security context
- Use {{with}} & some formatting cleanup
- Use Go 1.14 and kubectl v1.17
- Update Values schema
- Test against Kubernetes v1.18.0
- Update labels to match current Helm best practices. I ran `helm create kubeform` and copied the label and selector templates it generated.

Signed-off-by: Tamal Saha <tamal@appscode.com>